### PR TITLE
fix example of groupby-dsl

### DIFF
--- a/user_guide/src/examples/groupby_dsl/dataset.py
+++ b/user_guide/src/examples/groupby_dsl/dataset.py
@@ -10,4 +10,5 @@ dtypes = {
     "party": pl.Categorical,
 }
 
-dataset = pl.read_csv(url, dtype=dtypes).with_column(pl.col("birthday").str.strptime(pl.Date))
+with pl.StringCache():
+    dataset = pl.read_csv(url, dtype=dtypes).with_column(pl.col("birthday").str.strptime(pl.Date))


### PR DESCRIPTION
### Why

```
File "/opt/polars-book/user_guide/src/examples/groupby_dsl/snippet1.py", line 3, in <module>
    from .dataset import dataset
  File "/opt/polars-book/user_guide/src/examples/groupby_dsl/dataset.py", line 13, in <module>
    dataset = pl.read_csv(url, dtype=dtypes).with_column(pl.col("birthday").str.strptime(pl.Date))
  File "/opt/polars-book/.venv/lib/python3.8/site-packages/polars/io.py", line 387, in read_csv
    df = DataFrame.read_csv(
  File "/opt/polars-book/.venv/lib/python3.8/site-packages/polars/internals/frame.py", line 490, in read_csv
    self._df = PyDataFrame.read_csv(
pyo3_runtime.PanicException: Appending categorical data can only be done if they are made under the same global string cache. Consider using a global string cache.
```

### Reproduce Step

```
make run
```

### How it works

adding a global string cache