### PR TITLE
Fixes typos in Coming From Pandas

### DIFF
--- a/user_guide/src/coming_from_pandas.md
+++ b/user_guide/src/coming_from_pandas.md
@@ -30,7 +30,7 @@ df.with_columns([
 ])
 ```
 
-## Column asignment based on predicate
+## Column assignment based on predicate
 
 **pandas**
 
@@ -48,7 +48,7 @@ df.with_column(
 )
 ```
 
-Not that polars way is pure (the original DataFrame) is not modified. The `mask` is also not computed twice as in `pandas`.
+Note that polars way is pure, this means that the original DataFrame is not modified. The `mask` is also not computed twice as in `pandas`.
 You could prevent this in `pandas`, but that would require setting a temporary variable.
 Additionally polars can compute every branch of an `if -> then -> otherwise` in parallel. This is valuable, when the branches
 get more expensive to compute.


### PR DESCRIPTION
This pull request makes the explanation of the section "Column assignment based on predicate" easier to understand, and also fixes a typo in the beginning of the sentence. It also fixes typos on the section name and in it's text body.