### PR TITLE
fix offsets and use datetime.datetime

### DIFF
--- a/user_guide/src/examples/time_series/parsing_dates.py
+++ b/user_guide/src/examples/time_series/parsing_dates.py
@@ -1,13 +1,14 @@
 import polars as pl
+from datetime import datetime
 
 df = pl.read_csv("data/appleStock.csv", parse_dates=True)
 
 filtered_df = df.filter(
-    pl.col("Date") == pl.datetime(1995, 10, 16),
+    pl.col("Date") == datetime(1995, 10, 16),
 )
 
 filtered_range_df = df.filter(
-    pl.col("Date").is_between(pl.datetime(1995, 7, 1), pl.datetime(1995, 11, 1)),
+    pl.col("Date").is_between(datetime(1995, 7, 1), datetime(1995, 11, 1)),
 )
 
 annual_average_df = df.groupby_dynamic("Date", every="1y").agg(

--- a/user_guide/src/timeseries/parsing_dates_times.md
+++ b/user_guide/src/timeseries/parsing_dates_times.md
@@ -14,7 +14,7 @@
 When loading from a CSV file `Polars` attempts to parse dates and times if the `parse_dates` flag is set to `True`:
 
 ```python
-{{#include ../examples/time_series/parsing_dates.py:3:3}}
+{{#include ../examples/time_series/parsing_dates.py:4:4}}
 print(df)
 ```
 

--- a/user_guide/src/timeseries/selecting_dates.md
+++ b/user_guide/src/timeseries/selecting_dates.md
@@ -2,10 +2,13 @@
 
 Filtering date columns works in the same way as with other types of columns using the `.filter` method.
 
+Polars uses pythons native `datetime`, `date` and `timedelta` for equality comparissons between the datatypes
+`pl.Datetime`, `pl.Date` and `pl.Duration`.
+
 In the following example we use a time series of Apple stock prices.
 
 ```python
-{{#include ../examples/time_series/parsing_dates.py:3:3}}
+{{#include ../examples/time_series/parsing_dates.py:1:4}}
 print(df)
 ```
 
@@ -19,7 +22,7 @@ We can filter by a single date by casting the desired date string to a `Date` ob
 in a filter expression:
 
 ```python
-{{#include ../examples/time_series/parsing_dates.py:5:5}}
+{{#include ../examples/time_series/parsing_dates.py:6:8}}
 ```
 
 ```text
@@ -33,7 +36,7 @@ Note we are using the lowercase `datetime` method rather than the uppercase `Dat
 We can filter by a range of dates using the `is_between` method in a filter expression with the start and end dates:
 
 ```python
-{{#include ../examples/time_series/parsing_dates.py:7:7}}
+{{#include ../examples/time_series/parsing_dates.py:10:12}}
 ```
 
 ```text

--- a/user_guide/src/timeseries/temporal_groupby.md
+++ b/user_guide/src/timeseries/temporal_groupby.md
@@ -9,7 +9,7 @@ We can calculate temporal statistics using `groupby_dynamic` to group rows into 
 In following simple example we calculate the annual average closing price of Apple stock prices. We first load the data from CSV:
 
 ```python
-{{#include ../examples/time_series/parsing_dates.py:3:3}}
+{{#include ../examples/time_series/parsing_dates.py:4:4}}
 ```
 
 ```text
@@ -24,7 +24,7 @@ To get the annual average closing price we tell `groupby_dynamic` that we want t
 - take the mean values of the `Close` column for each year:
 
 ```python
-{{#include ../examples/time_series/parsing_dates.py:9:9}}
+{{#include ../examples/time_series/parsing_dates.py:14:17}}
 ```
 
 The annual average closing price is then:


### PR DESCRIPTION
Fixes offsets, I messed up in previous PR.

Also uses pythons `datetime.datetime` in favor of `pl.datetime`. @braaannigan I changed the comparisson code a bit, because using pythons native `datetime, date` and `timedelta` is idiomatic.