### PR TITLE
Fix description of `groupby_rolling`

### DIFF
--- a/user_guide/src/howcani/timeseries/temporal_groupby.md
+++ b/user_guide/src/howcani/timeseries/temporal_groupby.md
@@ -128,7 +128,7 @@ The rolling groupby is another entrance to the `groupby` context. But different 
 not fixed by a parameter `every` and `period`. In a rolling groupby the windows are not fixed at all! They are determined
 by the values in the `index_column`.
 
-So imagine having a time column with the values `{2021-01-01, 20210-01-05}` and a `period="5d"` this would create the following
+So imagine having a time column with the values `{2021-01-06, 20210-01-10}` and a `period="5d"` this would create the following
 windows:
 
 ```text


### PR DESCRIPTION
The [documentation](https://pola-rs.github.io/polars/py-polars/html/reference/api/polars.DataFrame.groupby_rolling.html?highlight=groupby_rolling#polars.DataFrame.groupby_rolling) specifies, that the default value for the parameter `offset` is `-period`. This means that by default, the generated windows will **end** (not start) at the date in the `index_column`.