### PR TITLE
fix printing wrong dataframe

### DIFF
--- a/user_guide/src/dsl/expressions.md
+++ b/user_guide/src/dsl/expressions.md
@@ -78,7 +78,7 @@ with the string `"am"`.
 
 ```python
 {{#include ../examples/expressions/expressions_examples_3.py:4:}}
-print(df)
+print(out)
 ```
 
 ```text
@@ -100,7 +100,7 @@ Finally, we multiply this with the result of a `sum` expression:
 
 ```python
 {{#include ../examples/expressions/expressions_examples_4.py:4:}}
-print(df)
+print(out)
 ```
 
 ```text


### PR DESCRIPTION
Fixing two cases where the dataframe is modified and stored as `out`, but the original `df` is printed.