### PR TITLE
DOC specify strategy in fill_null

### DIFF
--- a/user_guide/src/examples/missing_data/fill_strategies.py
+++ b/user_guide/src/examples/missing_data/fill_strategies.py
@@ -16,7 +16,7 @@ fill_literal_df = (
 )
 
 fill_forward_df = df.with_column(
-    pl.col("col2").fill_null("forward"),
+    pl.col("col2").fill_null(strategy="forward"),
 )
 
 fill_median_df = df.with_column(


### PR DESCRIPTION
The example in the docs is
```
shape: (3, 2)
┌──────┬─────────┐
│ col1 ┆ col2    │
│ ---  ┆ ---     │
│ i64  ┆ str     │
╞══════╪═════════╡
│ 1    ┆ 1       │
├╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ 2    ┆ forward │
├╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ 3    ┆ 3       │
└──────┴─────────┘
```
which looks a bit odd - I guess this was meant to be `strategy="forward"`?