### PR TITLE
Add Cargo.toml dependencies to quickstart

### DIFF
--- a/user_guide/src/quickstart/intro.md
+++ b/user_guide/src/quickstart/intro.md
@@ -97,6 +97,15 @@ fn main() -> Result<()> {
 }
 ```
 
+```text
+# Rust Cargo.toml dependencies
+
+[dependencies]
+polars = { version = "0.24.3", features = ["lazy"] }
+reqwest =  { version = "0.11.12", features = ["blocking"] }
+color-eyre = "0.6"
+```
+
 </div>
 
 When the data is stored locally, we can also use `scan_csv` in Python, or `LazyCsvReader` in Rust to run the query in lazy polars.


### PR DESCRIPTION
Getting the correct feature-flags for dependencies can be an unnecessary roadblock for user onboarding, so it'd be awesome to have the necessary `[dependencies]` located nearby the Rust example

Having it be a codeblock doesn't seem ideal, so I'm open to ideas on where this could live on the page