### PR TITLE
Adding extra newline to fix formatting

### DIFF
--- a/user_guide/src/dsl/expressions.md
+++ b/user_guide/src/dsl/expressions.md
@@ -42,6 +42,7 @@ df.select([
 ```
 
 </div>
+
 All expressions are run in parallel, meaning that separate `Polars` expressions are **embarrassingly parallel**. Note that within an expression there may be more parallelization going on.
 
 ## Expression examples


### PR DESCRIPTION
Formatting of italics + code-notation is breaking for the "All expressions..." line due to missing new line.