### PR TITLE
Fix the "Lazy quick start" on the "Getting started" page

### DIFF
--- a/user_guide/src/quickstart/intro.md
+++ b/user_guide/src/quickstart/intro.md
@@ -97,18 +97,20 @@ fn main() -> Result<()> {
 }
 ```
 
-```text
-# Rust Cargo.toml dependencies
+</div>
 
+When the data is stored locally, we can also use `scan_csv` in Python, or `LazyCsvReader` in Rust to run the query in lazy polars.
+
+### Note about Rust usage
+
+Some functionality is not enabled by default. It must be added as an additional feature. This can be enabled by directly adding it to your `Cargo.toml`
+
+```toml
 [dependencies]
 polars = { version = "0.24.3", features = ["lazy"] }
 reqwest =  { version = "0.11.12", features = ["blocking"] }
 color-eyre = "0.6"
 ```
-
-</div>
-
-When the data is stored locally, we can also use `scan_csv` in Python, or `LazyCsvReader` in Rust to run the query in lazy polars.
 
 ## References
 


### PR DESCRIPTION
issue #203 

- I fixed the "Lazy quick start" on the "Getting started" page.
I moved the explanation about `Cargo.toml` out of codeblock.

> I see. You had to use `text` because `tabbed-blocks` in `mdbook` does not support `toml`.
> 
> #199
> 
> > Having it be a codeblock doesn't seem ideal, so I'm open to ideas on where this could live on the page
> 
> It may be a good idea to follow the description in the "json.md" file.
> 
> https://pola-rs.github.io/polars-book/user-guide/howcani/io/json.html#note-about-rust-usage [user_guide/src/howcani/io/json.md](https://github.com/pola-rs/polars-book/blob/7490a9982073397025f1a5e589a20a077e1e5aba/user_guide/src/howcani/io/json.md)

![note_rsut_usage](https://user-images.githubusercontent.com/4991409/199581341-b83d0e83-e20c-40ae-a9c4-efc8efe4471b.png)

