### PR TITLE
Fix broken link for Python in Expressions API page

### DIFF
--- a/user_guide/src/dsl/api.md
+++ b/user_guide/src/dsl/api.md
@@ -3,6 +3,6 @@
 The full list of possible expressions is available on the `Expr`
 class definition in the reference guide.
 
-- [Python](POLARS_PY_REF_GUIDE/expression.html)
+- [Python](POLARS_PY_REF_GUIDE/expressions/index.html)
 - [Rust](POLARS_RS_REF_GUIDE/latest/polars/#expressions)
 - [JavaScript](https://pola-rs.github.io/nodejs-polars/interfaces/lazy_expr.Expr.html)


### PR DESCRIPTION
Original Python link in the current User Guide for the Expressions API at https://pola-rs.github.io/polars-book/user-guide/dsl/api.html

 https://pola-rs.github.io/polars/py-polars/html/reference/expression.html => 404

Correct link should be:

https://pola-rs.github.io/polars/py-polars/html/reference/expressions/index.html

