### PR TITLE
Added ddof argument to Rust code examples on the "Expressions" page

### DIFF
--- a/user_guide/src/examples/expressions/expressions.rs
+++ b/user_guide/src/examples/expressions/expressions.rs
@@ -38,8 +38,8 @@ fn main() -> Result<()> {
             min("random").alias("min"),
             max("random").alias("max"),
             col("random").max().alias("other_max"),
-            col("random").std().alias("std dev"),
-            col("random").var().alias("variance"),
+            col("random").std(1).alias("std dev"),
+            col("random").var(1).alias("variance"),
         ])
         .collect()?;
     println!("{}", out);


### PR DESCRIPTION
https://github.com/pola-rs/polars/pull/4315
Supported updates to `std` and `var` methods that added ddof argument.