### PR TITLE
Fixed sort option in "GroupBy" python code

### DIFF
--- a/user_guide/src/examples/groupby_dsl/snippet5.py
+++ b/user_guide/src/examples/groupby_dsl/snippet5.py
@@ -9,7 +9,7 @@ def get_person() -> pl.Expr:
 
 q = (
     dataset.lazy()
-    .sort("birthday")
+    .sort("birthday", reverse=True)
     .groupby(["state"])
     .agg(
         [

--- a/user_guide/src/examples/groupby_dsl/snippet6.py
+++ b/user_guide/src/examples/groupby_dsl/snippet6.py
@@ -9,7 +9,7 @@ def get_person() -> pl.Expr:
 
 q = (
     dataset.lazy()
-    .sort("birthday")
+    .sort("birthday", reverse=True)
     .groupby(["state"])
     .agg(
         [

--- a/user_guide/src/examples/groupby_dsl/snippet7.py
+++ b/user_guide/src/examples/groupby_dsl/snippet7.py
@@ -9,7 +9,7 @@ def get_person() -> pl.Expr:
 
 q = (
     dataset.lazy()
-    .sort("birthday")
+    .sort("birthday", reverse=True)
     .groupby(["state"])
     .agg(
         [


### PR DESCRIPTION
https://pola-rs.github.io/polars-book/user-guide/dsl/groupby.html#sorting

In the code example on the above page, the "youngest" and "oldest" results are reversed because the `revese` option of `sort` is not specified.

https://pola-rs.github.io/polars/py-polars/html/reference/dataframe/api/polars.DataFrame.sort.html#polars.DataFrame.sort
