### PR TITLE
fix typo in postgres markdown (#174)

### DIFF
--- a/user_guide/src/howcani/io/postgres.md
+++ b/user_guide/src/howcani/io/postgres.md
@@ -61,7 +61,7 @@ insert_stmt = sql.SQL("INSERT INTO {} ({}) VALUES({});").format(
 
 # make a connection
 conn = psycopg2.connect()
-cur = conn.cursort()
+cur = conn.cursor()
 
 # do the insert
 psycopg2.extras.execute_batch(cur, insert_stmt, df.rows())


### PR DESCRIPTION
Just a tiny typo in the postgres markdown.
Should resolve #174 as the other typo has been already fixed.