### PR TITLE
Fix missing Cursor import in Rust Lazy quick start

### DIFF
--- a/user_guide/src/quickstart/intro.md
+++ b/user_guide/src/quickstart/intro.md
@@ -73,6 +73,7 @@ print(
 use color_eyre::{Result};
 use polars::prelude::*;
 use reqwest::blocking::Client;
+use std::io::Cursor;
 
 fn main() -> Result<()> { 
     let data: Vec<u8> = Client::new()


### PR DESCRIPTION
Attempting to compile the Rust [Lazy quick start](https://pola-rs.github.io/polars-book/user-guide/quickstart/intro.html#lazy-quick-start) example currently results in an error. Importing std::io::Cursor fixes the issue.