### PR TITLE
created tabblocks to better align with design

### DIFF
--- a/user_guide/src/quickstart/intro.md
+++ b/user_guide/src/quickstart/intro.md
@@ -4,14 +4,24 @@
 
 Installing and using `Polars` is just a simple `pip install`, `cargo add`, or `yarn add` away.
 
-```shell
-$ # Installing for python
+<div class="tabbed-blocks">
+
+```python
+# Installing for python
 $ pip install polars
-$ # Installing into a Rust project
+```
+
+```rust,noplayground
+// Installing into a Rust project
 $ cargo add polars
-$ # Installing for Node
+```
+
+```js
+// Installing for Node
 $ yarn add nodejs-polars
 ```
+
+</div>
 
 All binaries are pre-built for `Python` v3.6+.
 


### PR DESCRIPTION
small change: created tabblocks on the quickstart page for rust, python and nodejs. fits the design of the book better. 

<img width="855" alt="image" src="https://user-images.githubusercontent.com/18343213/205875081-007d7c0b-4787-4e23-9529-75b3b42f528f.png">
