### PR TITLE
Fix broken links to API reference site

### DIFF
--- a/user_guide/src/dsl/expressions.md
+++ b/user_guide/src/dsl/expressions.md
@@ -174,7 +174,7 @@ print(out)
 A polars expression can also do an implicit GROUPBY, AGGREGATION, and JOIN in a single expression.
 In the examples below we do a GROUPBY OVER `"groups"` and AGGREGATE SUM of `"random"`, and in the next expression
 we GROUPBY OVER `"names"` and AGGREGATE a LIST of `"random"`. These window functions can be combined with other expressions
-and are an efficient way to determine group statistics. See more on those group statistics [here](POLARS_PY_REF_GUIDE/expression.html#aggregation).
+and are an efficient way to determine group statistics. See more on those group statistics [here](POLARS_PY_REF_GUIDE/expressions/aggregation.html).
 
 <div class="tabbed-blocks">
 

--- a/user_guide/src/dsl/folds.md
+++ b/user_guide/src/dsl/folds.md
@@ -1,7 +1,7 @@
 # Folds
 
-`Polars` provides expressions/methods for horizontal aggregations like [`sum`](POLARS_PY_REF_GUIDE/api/polars.DataFrame.sum.html),
-[`min`](POLARS_PY_REF_GUIDE/api/polars.DataFrame.min.html), [`mean`](POLARS_PY_REF_GUIDE/api/polars.DataFrame.mean.html),
+`Polars` provides expressions/methods for horizontal aggregations like [`sum`](POLARS_PY_REF_GUIDE/dataframe/api/polars.DataFrame.sum.html),
+[`min`](POLARS_PY_REF_GUIDE/dataframe/api/polars.DataFrame.min.html), [`mean`](POLARS_PY_REF_GUIDE/dataframe/api/polars.DataFrame.mean.html),
 etc. by setting the argument `axis=1`. However, when you need a more complex aggregation the default methods provided by the
 `Polars` library may not be sufficient. That's when `folds` come in handy.
 

--- a/user_guide/src/howcani/data/timestamps.md
+++ b/user_guide/src/howcani/data/timestamps.md
@@ -32,4 +32,4 @@ returning:
 {{#include ../../outputs/timestamps/output.txt}}
 ```
 
-All datetime functionality is shown in the [`dt` namespace](POLARS_PY_REF_GUIDE/series.html#timeseries).
+All datetime functionality is shown in the [`dt` namespace](POLARS_PY_REF_GUIDE/series/timeseries.html).

--- a/user_guide/src/howcani/df/aggregate.md
+++ b/user_guide/src/howcani/df/aggregate.md
@@ -18,4 +18,4 @@ yielding:
 {{#include ../../outputs/aggregate/output.txt}}
 ```
 
-See more in the [API docs of Expr](POLARS_PY_REF_GUIDE/expression.html#aggregation)
+See more in the [API docs of Expr](POLARS_PY_REF_GUIDE/expressions/aggregation.html)

--- a/user_guide/src/howcani/missing_data.md
+++ b/user_guide/src/howcani/missing_data.md
@@ -100,7 +100,7 @@ print(fill_forward_df)
 {{#include ../outputs/missing_data/fill_strategies_forward_df.txt}}
 ```
 
-See the [API docs](https://pola-rs.github.io/polars/py-polars/html/reference/api/polars.Series.fill_null.html) for other available strategies.
+See the [API docs](POLARS_PY_REF_GUIDE/series/api/polars.Series.fill_null.html) for other available strategies.
 
 ### Fill with an expression
 

--- a/user_guide/src/howcani/timeseries/parsing_dates_times.md
+++ b/user_guide/src/howcani/timeseries/parsing_dates_times.md
@@ -52,5 +52,5 @@ print(df_with_year)
 {{#include ../../outputs/time_series/parse_dates_with_year.txt}}
 ```
 
-See the [API docs](https://pola-rs.github.io/polars/py-polars/html/reference/series/timeseries.html)
+See the [API docs](POLARS_PY_REF_GUIDE/series/timeseries.html)
 for more date feature options.

--- a/user_guide/src/howcani/timeseries/temporal_groupby.md
+++ b/user_guide/src/howcani/timeseries/temporal_groupby.md
@@ -94,7 +94,7 @@ data points that in these gaps will not be a member of any group
               |--|
 ```
 
-See [the API pages](https://pola-rs.github.io/polars/py-polars/html/reference/api/polars.DataFrame.groupby_dynamic.html) for the full range of time periods.
+See [the API pages](POLARS_PY_REF_GUIDE/dataframe/api/polars.DataFrame.groupby_dynamic.html) for the full range of time periods.
 
 #### `truncate` parameter to set the start date for each group
 

--- a/user_guide/src/quickstart/quick-exploration-guide.md
+++ b/user_guide/src/quickstart/quick-exploration-guide.md
@@ -116,8 +116,8 @@ shape: (3, 3)
 
 Additional information
 
-- Link to `Series` in the Reference guide: [link](https://pola-rs.github.io/polars/py-polars/html/reference/series/index.html)
-- Link to `DataFrames` in the Reference guide: [link](https://pola-rs.github.io/polars/py-polars/html/reference/dataframe/index.html)
+- Link to `Series` in the Reference guide: [link](POLARS_PY_REF_GUIDE/series/index.html)
+- Link to `DataFrames` in the Reference guide: [link](POLARS_PY_REF_GUIDE/dataframe/index.html)
 
 ### From files
 
@@ -230,7 +230,7 @@ shape: (3, 3)
 Additional information
 
 - Read more about `IO` in the Polars Book: [link](../howcani/io/intro.html)
-- Link to `IO` in the Reference guide: [link](https://pola-rs.github.io/polars/py-polars/html/reference/io.html)
+- Link to `IO` in the Reference guide: [link](POLARS_PY_REF_GUIDE/io.html)
 
 ## Viewing data
 
@@ -373,9 +373,9 @@ shape: (7, 5)
 
 Additional information
 
-- Link to aggregations on `DataFrames` in the Reference guide: [link](https://pola-rs.github.io/polars/py-polars/html/reference/dataframe/aggregation.html)
-- Link to descriptive `DataFrame` functions in the Reference guide: [link](https://pola-rs.github.io/polars/py-polars/html/reference/dataframe/descriptive.html)
-- Link to `DataFrame` attributes in the Reference guide: [link](https://pola-rs.github.io/polars/py-polars/html/reference/dataframe/attributes.html)
+- Link to aggregations on `DataFrames` in the Reference guide: [link](POLARS_PY_REF_GUIDE/dataframe/aggregation.html)
+- Link to descriptive `DataFrame` functions in the Reference guide: [link](POLARS_PY_REF_GUIDE/dataframe/descriptive.html)
+- Link to `DataFrame` attributes in the Reference guide: [link](POLARS_PY_REF_GUIDE/dataframe/attributes.html)
 
 ## Expressions
 
@@ -830,7 +830,7 @@ shape: (8, 5)
 Additional information
 
 - Link to `joins` in the Polars Book: [link](../howcani/combining_data/joining.md)
-- More information about `joins` in the Reference guide [link](https://pola-rs.github.io/polars/py-polars/html/reference/dataframe/api/polars.DataFrame.join.html#polars.DataFrame.join)
+- More information about `joins` in the Reference guide [link](POLARS_PY_REF_GUIDE/dataframe/api/polars.DataFrame.join.html#polars.DataFrame.join)
 
 ### Concat
 
@@ -868,7 +868,7 @@ shape: (8, 6)
 Additional information
 
 - Link to `concatenation` in the Polars Book: [link](../howcani/combining_data/concatenating.md)
-- More information about `concatenation` in the Reference guide [link](https://pola-rs.github.io/polars/py-polars/html/reference/api/polars.concat.html#polars.concat)
+- More information about `concatenation` in the Reference guide [link](POLARS_PY_REF_GUIDE/api/polars.concat.html#polars.concat)
 
 ## Remaining topics
 
@@ -876,5 +876,5 @@ This guide was a quick introduction to some of the most used functions within `P
 
 - Dealing with timeseries [link](../howcani/timeseries/intro.md)
 - Processing missing data [link](../howcani/missing_data.md)
-- Reading data from Pandas DataFrame or Numpy array [link](https://pola-rs.github.io/polars/py-polars/html/reference/functions.html#conversion)
+- Reading data from Pandas DataFrame or Numpy array [link](POLARS_PY_REF_GUIDE/functions.html#conversion)
 - Working with the Lazy API [link](../optimizations/)


### PR DESCRIPTION
Various links to the API reference site are currently broken.

This change updates the URLs from the `section.html#subsection` pattern to the new `section/subsection.html` pattern.

Additionally, it standardizes the use of `POLARS_PY_REF_GUIDE` across the codebase by replacing occurrences of https://pola-rs.github.io/polars/py-polars/html/reference with the `POLARS_PY_REF_GUIDE` shorthand.