### PR TITLE
Update df macro usage

### DIFF
--- a/user_guide/src/examples/expressions/apply_function.rs
+++ b/user_guide/src/examples/expressions/apply_function.rs
@@ -4,10 +4,10 @@ use color_eyre::Result;
 use polars::prelude::*;
 
 fn main() -> Result<()> {
-    let df = df! [
-        "keys" => ["a", "a", "b"],
-        "values" => [10, 7, 1],
-    ]?;
+    let df = df! (
+        "keys" => &["a", "a", "b"],
+        "values" => &[10, 7, 1],
+    )?;
 
     println!("{}", &df);
 

--- a/user_guide/src/examples/expressions/contexts.rs
+++ b/user_guide/src/examples/expressions/contexts.rs
@@ -7,12 +7,12 @@ use rand::{thread_rng, Rng};
 fn main() -> Result<()> {
     let mut arr = [0f64; 5];
     thread_rng().fill(&mut arr);
-    let df = df! [
-        "nrs" => [Some(1), Some(2), Some(3), None, Some(5)],
-        "names" => [Some("foo"), Some("ham"), Some("spam"), Some("eggs"), None],
-        "random" => arr,
-        "groups" => ["A", "A", "B", "C", "B"],
-    ]?;
+    let df = df! (
+        "nrs" => &[Some(1), Some(2), Some(3), None, Some(5)],
+        "names" => &[Some("foo"), Some("ham"), Some("spam"), Some("eggs"), None],
+        "random" => &arr,
+        "groups" => &["A", "A", "B", "C", "B"],
+    )?;
 
     // ANCHOR: select
     let out = df

--- a/user_guide/src/examples/expressions/expressions.rs
+++ b/user_guide/src/examples/expressions/expressions.rs
@@ -7,12 +7,12 @@ fn main() -> Result<()> {
     let mut arr = [0f64; 5];
     thread_rng().fill(&mut arr);
 
-    let df = df! [
-        "nrs" => [Some(1), Some(2), Some(3), None, Some(5)],
-        "names" => [Some("foo"), Some("ham"), Some("spam"), Some("eggs"), None],
-        "random" => arr,
-        "groups" => ["A", "A", "B", "C", "B"],
-    ]?;
+    let df = df! (
+        "nrs" => &[Some(1), Some(2), Some(3), None, Some(5)],
+        "names" => &[Some("foo"), Some("ham"), Some("spam"), Some("eggs"), None],
+        "random" => &arr,
+        "groups" => &["A", "A", "B", "C", "B"],
+    )?;
 
     println!("{}", &df);
     // ANCHOR_END: dataset

--- a/user_guide/src/examples/expressions/fold.rs
+++ b/user_guide/src/examples/expressions/fold.rs
@@ -3,10 +3,10 @@ use polars::prelude::*;
 
 fn main() -> Result<()> {
     // ANCHOR: manual_sum
-    let df = df![
-        "a" => [1, 2, 3],
-        "b" => [10, 20, 30],
-    ]?;
+    let df = df!(
+        "a" => &[1, 2, 3],
+        "b" => &[10, 20, 30],
+    )?;
 
     let out = df
         .lazy()
@@ -16,10 +16,10 @@ fn main() -> Result<()> {
     // ANCHOR_END: manual_sum
 
     // ANCHOR: conditional
-    let df = df![
-        "a" => [1, 2, 3],
-        "b" => [0, 1, 2],
-    ]?;
+    let df = df!(
+        "a" => &[1, 2, 3],
+        "b" => &[0, 1, 2],
+    )?;
 
     let out = df
         .lazy()
@@ -33,10 +33,10 @@ fn main() -> Result<()> {
     // ANCHOR_END: conditional
 
     // ANCHOR: string
-    let df = df![
-        "a" => ["a", "b", "c"],
-        "b" => [1, 2, 3],
-    ]?;
+    let df = df!(
+        "a" => &["a", "b", "c"],
+        "b" => &[1, 2, 3],
+    )?;
 
     let out = df
         .lazy()

--- a/user_guide/src/examples/expressions/list_row_wise.rs
+++ b/user_guide/src/examples/expressions/list_row_wise.rs
@@ -3,12 +3,12 @@ use polars::prelude::*;
 
 fn main() -> Result<()> {
     // ANCHOR: dataset
-    let grades = df![
-        "student" => ["bas", "laura", "tim", "jenny"],
-        "arithmetic" => [10, 5, 6, 8],
-        "biology" => [4, 6, 2, 7],
-        "geography" => [8, 4, 9, 7],
-    ]?;
+    let grades = df!(
+        "student" => &["bas", "laura", "tim", "jenny"],
+        "arithmetic" => &[10, 5, 6, 8],
+        "biology" => &[4, 6, 2, 7],
+        "geography" => &[8, 4, 9, 7],
+    )?;
     println!("{}", grades);
     // ANCHOR_END: dataset
 

--- a/user_guide/src/examples/expressions/map_function.rs
+++ b/user_guide/src/examples/expressions/map_function.rs
@@ -2,10 +2,10 @@ use color_eyre::Result;
 use polars::prelude::*;
 
 fn main() -> Result<()> {
-    let df = df! [
-        "keys" => ["a", "a", "b"],
-        "values" => [10, 7, 1],
-    ]?;
+    let df = df! (
+        "keys" => &["a", "a", "b"],
+        "values" => &[10, 7, 1],
+    )?;
 
     let out = df
         .lazy()

--- a/user_guide/src/examples/expressions/window.rs
+++ b/user_guide/src/examples/expressions/window.rs
@@ -95,12 +95,12 @@ fn main() -> Result<()> {
     println!("{:?}", out);
     // ANCHOR_END: more
 
-    let df = df! [
-        "foo" => [11, 22, 33, 44, 55],
-        "groups" => [Some("foo"), Some("ham"), Some("spam"), Some("eggs"), None],
-        "x" => [1, 2, 3, 4, 5],
-        "y" => [3, 4, 5, 6, 7],
-    ]?
+    let df = df! (
+        "foo" => &[11, 22, 33, 44, 55],
+        "groups" => &[Some("foo"), Some("ham"), Some("spam"), Some("eggs"), None],
+        "x" => &[1, 2, 3, 4, 5],
+        "y" => &[3, 4, 5, 6, 7],
+    )?
     .lazy();
 
     let _temp = df

--- a/user_guide/src/howcani/io/csv.md
+++ b/user_guide/src/howcani/io/csv.md
@@ -35,8 +35,8 @@ df.write_csv("path.csv")
 use polars::prelude::*;
 
 let mut df = df!(
-    "foo" => [1, 2, 3],
-    "bar" => [None, Some("bak"), Some("baz")],
+    "foo" => &[1, 2, 3],
+    "bar" => &[None, Some("bak"), Some("baz")],
 )
 .unwrap();
 

--- a/user_guide/src/howcani/io/json.md
+++ b/user_guide/src/howcani/io/json.md
@@ -56,8 +56,8 @@ df.write_ndjson("path.json")
 use polars::prelude::*;
 
 let mut df = df!(
-    "foo" => [1, 2, 3],
-    "bar" => [None, Some("bak"), Some("baz")],
+    "foo" => &[1, 2, 3],
+    "bar" => &[None, Some("bak"), Some("baz")],
 )
 .unwrap();
 
@@ -80,7 +80,7 @@ JsonWriter::new(&mut file)
 
 ## Scan
 
-`Polars` allows you to *scan* a JSON input **only for newline delimited json**. Scanning delays the actual parsing of the
+`Polars` allows you to _scan_ a JSON input **only for newline delimited json**. Scanning delays the actual parsing of the
 file and instead returns a lazy computation holder called a `LazyFrame`.
 
 <div class="tabbed-blocks">

--- a/user_guide/src/howcani/io/parquet.md
+++ b/user_guide/src/howcani/io/parquet.md
@@ -34,8 +34,8 @@ df.write_parquet("path.parquet")
 
 ```rust,noplayground
 let mut df = df!(
-    "foo" => [1, 2, 3],
-    "bar" => [None, Some("bak"), Some("baz")],
+    "foo" => &[1, 2, 3],
+    "bar" => &[None, Some("bak"), Some("baz")],
 )
 .unwrap();
 

--- a/user_guide/src/notebooks/introduction_polars-rs.ipynb
+++ b/user_guide/src/notebooks/introduction_polars-rs.ipynb
@@ -1027,17 +1027,22 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Rust",
-   "language": "rust",
-   "name": "rust"
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": "rust",
    "file_extension": ".rs",
    "mimetype": "text/rust",
-   "name": "rust",
+   "name": "python",
    "pygment_lexer": "rust",
-   "version": ""
+   "version": "3.10.4 (main, Dec 19 2022, 20:24:16) [GCC 9.4.0]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "3ad933181bd8a04b432d3370b9dc3b0662ad032c4dfaa4e4f1596c548f763858"
+   }
   }
  },
  "nbformat": 4,

--- a/user_guide/src/performance/strings.md
+++ b/user_guide/src/performance/strings.md
@@ -71,9 +71,9 @@ use polars::prelude::*;
 
 fn main() {
     let words = "All that glitters is not gold".split(' ').collect::<Vec<_>>();
-    let df = df! {
-        "shakespear" => words
-    }.unwrap();
+    let df = df! (
+        "shakespear" => &words
+    ).unwrap();
     println!("{df}");
 }
 ```
@@ -97,16 +97,16 @@ use polars::{prelude::*, toggle_string_cache};
 
 fn main() {
     toggle_string_cache(true);
-    let lf1 = df! {
-        "a" => ["foo", "bar", "ham"],
-        "b" => [1, 2, 3]
-    }
+    let lf1 = df! (
+        "a" => &["foo", "bar", "ham"],
+        "b" => &[1, 2, 3]
+    )
     .unwrap()
     .lazy();
-    let lf2 = df! {
-        "a" => ["foo", "spam", "eggs"],
-        "b" => [3,2,2]
-    }
+    let lf2 = df! (
+        "a" => &["foo", "spam", "eggs"],
+        "b" => &[3,2,2]
+    )
     .unwrap()
     .lazy();
 


### PR DESCRIPTION
# Summary

There are outdated versions of the `df!` macro in several places in the book.
For instance on this page: https://pola-rs.github.io/polars-book/user-guide/dsl/expressions.html
Latest `df!` macro documentation: https://pola-rs.github.io/polars/polars/frame/struct.DataFrame.html#using-a-macro

### Old version example

```rust
let df = df! [
    "keys" => ["a", "a", "b"],
    "values" => [10, 7, 1],
]?;
```

### New version example

```rust
let df = df! (
    "keys" => &["a", "a", "b"],
    "values" => &[10, 7, 1],
)?;
```