### PR TITLE
Update intro.md with missing dependencies

### DIFF
--- a/user_guide/src/quickstart/intro.md
+++ b/user_guide/src/quickstart/intro.md
@@ -81,6 +81,7 @@ print(
 
 ```rust,noplayground
 use color_eyre::{Result};
+use std::io::Cursor;
 use polars::prelude::*;
 use reqwest::blocking::Client;
 


### PR DESCRIPTION
Hey polars team 👋 ,

I tried to run the Rust example locally, and I found that `Cursor` dependency was missed. I added on the quickStart documentation to make easier copy + paste for those trying Polars with Rustlang.