### PR TITLE
docs(python): Reference chrono strftime instead of strftime.org

### DIFF
--- a/user_guide/src/howcani/data/timestamps.md
+++ b/user_guide/src/howcani/data/timestamps.md
@@ -14,7 +14,7 @@
 `Polars` try to guess the format of the date\[time\], or explicitly provide a `fmt`
 rule.
 
-For instance (check [this link](https://strftime.org/) for an comprehensive list):
+For instance (check [this link](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) for an comprehensive list):
 
 - `"%Y-%m-%d"` for `"2020-12-31"`
 - `"%Y/%B/%d"` for `"2020/December/31"`


### PR DESCRIPTION
The chrono strptime isn't quite the same as the Python one https://github.com/chronotope/chrono/issues/945 , so I'm suggesting to link to the chrono docs instead