### PR TITLE
fix fill_null("forward")

### DIFF
--- a/user_guide/src/examples/df_manipulations/__main__.py
+++ b/user_guide/src/examples/df_manipulations/__main__.py
@@ -26,7 +26,7 @@ with open(f"{path}/drop_nulls.txt", "w") as f:
     f.write(f"{df.drop_nulls()}\n")
 
 with open(f"{path}/fill_na.txt", "w") as f:
-    f.write(f"{df.fill_null('forward')}\n")
+    f.write(f"{df.fill_null(strategy='forward')}\n")
 
 with open(f"{path}/get_columns.txt", "w") as f:
     f.write(f"{df.columns}\n")

--- a/user_guide/src/examples/time_series/resampling_example.py
+++ b/user_guide/src/examples/time_series/resampling_example.py
@@ -9,6 +9,6 @@ df = pl.DataFrame(
         "values": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
     }
 )
-out1 = df.upsample(time_column="time", every="15m").fill_null("forward")
+out1 = df.upsample(time_column="time", every="15m").fill_null(strategy="forward")
 
-out2 = df.upsample(time_column="time", every="15m").interpolate().fill_null("forward")
+out2 = df.upsample(time_column="time", every="15m").interpolate().fill_null(strategy="forward")


### PR DESCRIPTION
fairly confident these were meant to be `strategy="forward"`? else it looks like this

```
shape: (13, 3)
┌─────────────────────┬─────────┬────────┐
│ time                ┆ groups  ┆ values │
│ ---                 ┆ ---     ┆ ---    │
│ datetime[μs]        ┆ str     ┆ f64    │
╞═════════════════════╪═════════╪════════╡
│ 2021-12-16 00:00:00 ┆ a       ┆ 1.0    │
│ 2021-12-16 00:15:00 ┆ forward ┆ null   │
│ 2021-12-16 00:30:00 ┆ a       ┆ 2.0    │
│ 2021-12-16 00:45:00 ┆ forward ┆ null   │
│ ...                 ┆ ...     ┆ ...    │
│ 2021-12-16 02:15:00 ┆ forward ┆ null   │
│ 2021-12-16 02:30:00 ┆ a       ┆ 6.0    │
│ 2021-12-16 02:45:00 ┆ forward ┆ null   │
│ 2021-12-16 03:00:00 ┆ a       ┆ 7.0    │
└─────────────────────┴─────────┴────────┘
```

as opposed to
```
In [7]: df.upsample(time_column="time", every="15m").fill_null(strategy="forward")
Out[7]: 
shape: (13, 3)
┌─────────────────────┬────────┬────────┐
│ time                ┆ groups ┆ values │
│ ---                 ┆ ---    ┆ ---    │
│ datetime[μs]        ┆ str    ┆ f64    │
╞═════════════════════╪════════╪════════╡
│ 2021-12-16 00:00:00 ┆ a      ┆ 1.0    │
│ 2021-12-16 00:15:00 ┆ a      ┆ 1.0    │
│ 2021-12-16 00:30:00 ┆ a      ┆ 2.0    │
│ 2021-12-16 00:45:00 ┆ a      ┆ 2.0    │
│ ...                 ┆ ...    ┆ ...    │
│ 2021-12-16 02:15:00 ┆ b      ┆ 5.0    │
│ 2021-12-16 02:30:00 ┆ a      ┆ 6.0    │
│ 2021-12-16 02:45:00 ┆ a      ┆ 6.0    │
│ 2021-12-16 03:00:00 ┆ a      ┆ 7.0    │
└─────────────────────┴────────┴────────┘
```