### PR TITLE
Make use of `usecols` in pandas

### DIFF
--- a/user_guide/src/coming_from_pandas.md
+++ b/user_guide/src/coming_from_pandas.md
@@ -114,7 +114,7 @@ The CSV file has numerous columns but we just want to do a groupby on one of the
 columns (`id1`) and then sum by a value column (`v1`). In `Pandas` this would be:
 
 ```python
-    df = pd.read_csv(csv_file)
+    df = pd.read_csv(csv_file, usecols=['id1','v1'])
     grouped_df = df.loc[:,['id1','v1']].groupby('id1').sum('v1')
 ```
 


### PR DESCRIPTION
To be fair to pandas, one should take advantage of `usecols` which makes the pandas and polars code more comparable.

It is still evident that polars is DRYer, as it doesn't force the user to explicitly note which columns to load.