### PR TITLE
Fix typos and remove redundant code cells

### DIFF
--- a/user_guide/src/howcani/missing_data.md
+++ b/user_guide/src/howcani/missing_data.md
@@ -124,7 +124,7 @@ In addition, we can fill nulls with interpolation (without using the `fill_null`
 
 ```python
 {{#include ../examples/missing_data/fill_strategies.py:26:28}}
-print(fill_interpolation)
+print(fill_interpolation_df)
 ```
 
 ```text

--- a/user_guide/src/howcani/timeseries/temporal_groupby.md
+++ b/user_guide/src/howcani/timeseries/temporal_groupby.md
@@ -10,6 +10,7 @@ In following simple example we calculate the annual average closing price of App
 
 ```python
 {{#include ../../examples/time_series/parsing_dates.py:4:4}}
+print(df)
 ```
 
 ```text
@@ -151,7 +152,7 @@ Below is an example with a dynamic groupby.
 
 ```python
 {{#include ../../examples/time_series/dynamic_ds.py:0:}}
-print(out)
+print(df)
 ```
 
 ```text

--- a/user_guide/src/notebooks/introduction_polars-py.ipynb
+++ b/user_guide/src/notebooks/introduction_polars-py.ipynb
@@ -549,14 +549,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "89846e44",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
    "execution_count": 6,
    "id": "regional-spencer",
    "metadata": {},


### PR DESCRIPTION
- Fixes typos in variable names
- Removes redundant code cell in a notebook