### PR TITLE
Clarified wording in How Can I / Numpy

### DIFF
--- a/user_guide/src/howcani/interop/numpy.md
+++ b/user_guide/src/howcani/interop/numpy.md
@@ -6,7 +6,7 @@ Element-wise functions such as `np.exp()`, `np.cos()`, `np.div()`, *etc.* all wo
 almost zero overhead.
 
 However, as a `Polars`-specific remark: missing values are a separate bitmask and are not
-visible by `NumPy`. It can yield to a window function or a `np.convolve()` giving
+visible by `NumPy`. This can lead to a window function or a `np.convolve()` giving
 flawed or incomplete results.
 
 Convert a `Polars` `Series` to a `NumPy` array with the `.to_numpy()` method.


### PR DESCRIPTION
**Summary** 
Small clarification in Numpy documentation

**Features**
Changed "It can yield" to "This can lead" -- more descriptive and no initial confusion about generators `yield`

**Test Plan**
No other changes than markdown, so assuming no testing needed.
