### PR TITLE
timestamp: clarify that strptime produces DateTime not Duration

### DIFF
--- a/user_guide/src/howcani/data/timestamps.md
+++ b/user_guide/src/howcani/data/timestamps.md
@@ -1,16 +1,14 @@
 # Timestamp parsing
 
-`Polars` offers `4` time datatypes:
+`Polars` offers `3` absolute time datatypes
 
 - `pl.Date`, to be used for **date** objects: the number of days since the UNIX epoch as
   a 32 bit signed integer.
 - `pl.Datetime`, to be used for **datetime** objects: the number of nanoseconds since the
   UNIX epoch as a 64 bit signed integer.
 - `pl.Time`, encoded as the number of nanoseconds since midnight.
-- `pl.Duration`, to be used for **timedelta** objects: the difference between Date,
-  Datetime or Time as a 64 bit signed integer offering microsecond resolution.
 
-`Polars` string (`pl.Utf8`) datatypes can be parsed as either of them. You can let
+`Polars` string (`pl.Utf8`) datatypes can be parsed as any of them. You can let
 `Polars` try to guess the format of the date\[time\], or explicitly provide a `fmt`
 rule.
 
@@ -33,3 +31,5 @@ returning:
 ```
 
 All datetime functionality is shown in the [`dt` namespace](POLARS_PY_REF_GUIDE/series/timeseries.html).
+
+Note that `Polars` also offers a relative time datatype: `pl.Duration` to be used for **timedelta** objects, the difference between Date, Datetime or Time as a 64 bit signed integer offering microsecond resolution. The absolute time datatypes _cannot_ be safely cast to `pl.Duration`, as they mean entirely different things. If you have a timestamp like `00:46:22` or `58H13M25S` you should write your own parser using for example [str.extract](https://pola-rs.github.io/polars/py-polars/html/reference/series/api/polars.Series.str.extract.html).


### PR DESCRIPTION
Prompted by: https://stackoverflow.com/questions/75654140/trouble-with-strptime-conversion-of-duration-time-string I went down a rabbit hole into how Dates and Times and Durations are handled.

The docs as of now are misleading, as DateTime cannot be safely cast to Time.

Maybe there should be a section on "Duration Stamp" parsing. The hacks suggested in the SO answer are not ideal. E.g. duration can certainly be negative. What about Time? Probably not. So Duration stamps should be handled separately. Otherwise all sorts of subtle bugs can creep in.

This PR is an attempt to defuse the ambiguity without proposing a clear way forward - this should be separately handled.