### PR TITLE
FIX Updated 2 Rust examples to follow 0.27.1+ `fold_exprs` function signature

### DIFF
--- a/user_guide/src/examples/expressions/fold.rs
+++ b/user_guide/src/examples/expressions/fold.rs
@@ -10,7 +10,7 @@ fn main() -> Result<()> {
 
     let out = df
         .lazy()
-        .select([fold_exprs(lit(0), |acc, x| Ok(acc + x), [col("*")]).alias("sum")])
+        .select([fold_exprs(lit(0), |acc, x| Ok(Some(acc + x)), [col("*")]).alias("sum")])
         .collect()?;
     println!("{}", out);
     // ANCHOR_END: manual_sum
@@ -25,7 +25,7 @@ fn main() -> Result<()> {
         .lazy()
         .filter(fold_exprs(
             lit(true),
-            |acc, x| acc.bitand(&x),
+            |acc, x| Some(acc.bitand(&x)),
             [col("*").gt(1)],
         ))
         .collect()?;


### PR DESCRIPTION
This PR 
- Since 0.27.1, `polars::prelude::fold_exprs` expected an `Fn` that returns `Result<Option<Series>, PolarsError>` instead of `Result<Series, PolarsError>`.
- `Some()` had been added to the Rust Examples of "Manual Sum" and "Conditional" to follow this new signature.

This PR addresses #287 .