### PR TITLE
add lazy_api to make run so outputs are generated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ data: .venv
 run: data
 	./tasks.sh process_nbook introduction_polars-py
 	./tasks.sh process_nbook introduction_polars-rs
+	$(PYTHON) -m user_guide.src.examples.lazy_api
 	$(PYTHON) -m user_guide.src.examples.testing
 	$(PYTHON) -m user_guide.src.examples.multiple_files
 	$(PYTHON) -m user_guide.src.examples.combining_data


### PR DESCRIPTION
I had forgotten to add a line to the makefile to execute the lazy_api examples (I do it in the command line during dev to avoid running all of them). 

I've added this line now which fixes the lazy API examples. 

I've also updated the list of functions that support streaming as per #277 

@MarcoGorelli There are time zone examples that reference a python script called examples/time_series/time_zones/mixed_offsets.py. However, I'm not sure if this has been committed. Can you look into this?

@lucazanna Can you try running make serve again to check that it runs properly for the lazy API examples?