### PR TITLE
parse_dates changed to try_parse_dates in quickstart guide

### DIFF
--- a/user_guide/src/examples/quickstart/read_csv_datetime.py
+++ b/user_guide/src/examples/quickstart/read_csv_datetime.py
@@ -1,3 +1,3 @@
 import polars as pl
 
-df_csv_with_dates = pl.read_csv("output.csv", parse_dates=True)
+df_csv_with_dates = pl.read_csv("output.csv", try_parse_dates=True)

--- a/user_guide/src/quickstart/quick-exploration-guide.md
+++ b/user_guide/src/quickstart/quick-exploration-guide.md
@@ -104,7 +104,7 @@ print(df_csv_with_dates)
 {{#include ../outputs/quickstart/output.csv}}
 ```
 
-You can add `parse_dates=True` to ensure that date column(s) are set as datetime.
+You can add `try_parse_dates=True` to ensure that date column(s) are set as datetime.
 
 #### json
 


### PR DESCRIPTION
The latest version of polars changed the parse_dates argument to try_parse_dates(https://github.com/pola-rs/polars/pull/6987). I updated the quickstart guide accordingly.