### PR TITLE
Dark mode

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -28,8 +28,11 @@ To update your own repo with code pushed on the upstream repo:
 
 ### Building locally
 To build the documentation locally you will need to install the python libraries defined in the `requirements.txt` file.
+
+Then run `python scripts/people.py` to build the list of contributors.
+
 <!-- markdown-link-check-disable -->
-When these are installed run `mkdocs serve` to run the server. You can then view the docs at http://localhost:8000/
+When these steps are done run `mkdocs serve` to run the server. You can then view the docs at http://localhost:8000/
 <!-- markdown-link-check-enable -->
 
 ### Want to discuss something?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,18 @@
 site_name: Polars User Guide
 site_url: https://pola-rs.github.io/polars-book
 theme:
+  palette:
+  # Palette toggle for light mode
+  - scheme: default
+    toggle:
+      icon: material/brightness-7
+      name: Switch to dark mode
+
+  # Palette toggle for dark mode
+  - scheme: slate
+    toggle:
+      icon: material/brightness-4
+      name: Switch to light mode
   name: material
   custom_dir: overrides
   logo: assets/logo.png
@@ -115,3 +127,4 @@ nav:
       - user-guide/misc/alternatives.md
       - user-guide/misc/reference-guides.md
       - user-guide/misc/contributing.md
+


### PR DESCRIPTION
Adds a toggleable dark mode:
![image](https://user-images.githubusercontent.com/28559054/236131024-c4aeccc9-9988-4f8b-93e2-06bb89656901.png)

I copied the schemes from the mkdocs material docs: [Color palette toggle](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#color-palette-toggle)

Also adds a short line to `Contributing.md` about having to run the script `people.py`. If you do `mkdocs serve` before that, you get the error:
```bash
ERROR    -  Error reading page 'index.md': Snippet at path 'docs/people.md' could not be found
```

Closes #312 