### PR TITLE
Allow deployment from non-master branch for forks

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,5 +1,6 @@
 name: deploy
 on:
+  workflow_dispatch:
   push:
     branches:
       - master 


### PR DESCRIPTION
For forks it is useful to work from feature branches. However currently when you work on a non-master branch there is no way to deploy the fork in your own repository since the github actions are defined to deploy on master/main branches only. This PR adds a manual trigger allowing you to deploy manually from non-master branches.

The local development server of mkdocs is slightly different (e.g. path handling).  Deploying your fork on a feature branch is useful to test if everything is working. 