### PR TITLE
fix window example

### DIFF
--- a/docs/src/python/user-guide/expressions/window.py
+++ b/docs/src/python/user-guide/expressions/window.py
@@ -39,7 +39,7 @@ print(filtered)
 # --8<-- [start:sort]
 out = filtered.with_columns(
     [
-        pl.col(["Name", "Speed"]).sort(descending=True).over("Type 1"),
+        pl.col(["Name", "Speed"]).sort_by("Speed",descending=True).over("Type 1"),
     ]
 )
 print(out)

--- a/docs/src/python/user-guide/expressions/window.py
+++ b/docs/src/python/user-guide/expressions/window.py
@@ -39,7 +39,7 @@ print(filtered)
 # --8<-- [start:sort]
 out = filtered.with_columns(
     [
-        pl.col(["Name", "Speed"]).sort_by("Speed",descending=True).over("Type 1"),
+        pl.col(["Name", "Speed"]).sort_by("Speed", descending=True).over("Type 1"),
     ]
 )
 print(out)

--- a/docs/src/rust/user-guide/expressions/window.rs
+++ b/docs/src/rust/user-guide/expressions/window.rs
@@ -56,7 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [start:sort]
     let out = filtered
         .lazy()
-        .with_columns([cols(["Name", "Speed"]).sort(true).over(["Type 1"])])
+        .with_columns([cols(["Name", "Speed"]).sort_by(["Speed"],[true]).over(["Type 1"])])
         .collect()?;
     println!("{}", out);
     // --8<-- [end:sort]


### PR DESCRIPTION
fix #309 

Instead of sorting both columns independently, sort_by sorts them together fixing the example 