### PR TITLE
People hook

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,5 +21,4 @@ jobs:
           path: .cache
       - run: pip install -r requirements.txt
       - run: sudo apt-get install -y graphviz
-      - run: python scripts/people.py
       - run: mkdocs gh-deploy --force

--- a/Contributing.md
+++ b/Contributing.md
@@ -29,10 +29,8 @@ To update your own repo with code pushed on the upstream repo:
 ### Building locally
 To build the documentation locally you will need to install the python libraries defined in the `requirements.txt` file.
 
-Then run `python scripts/people.py` to build the list of contributors.
-
 <!-- markdown-link-check-disable -->
-When these steps are done run `mkdocs serve` to run the server. You can then view the docs at http://localhost:8000/
+When these are installed run `mkdocs serve` to run the server. You can then view the docs at http://localhost:8000/
 <!-- markdown-link-check-enable -->
 
 ### Want to discuss something?

--- a/Contributing.md
+++ b/Contributing.md
@@ -28,8 +28,11 @@ To update your own repo with code pushed on the upstream repo:
 
 ### Building locally
 To build the documentation locally you will need to install the python libraries defined in the `requirements.txt` file.
+
+Then run `python scripts/people.py` to build the list of contributors.
+
 <!-- markdown-link-check-disable -->
-When these are installed run `mkdocs serve` to run the server. You can then view the docs at http://localhost:8000/
+When these steps are done run `mkdocs serve` to run the server. You can then view the docs at http://localhost:8000/
 <!-- markdown-link-check-enable -->
 
 ### Want to discuss something?

--- a/Contributing.md
+++ b/Contributing.md
@@ -29,11 +29,6 @@ To update your own repo with code pushed on the upstream repo:
 ### Building locally
 To build the documentation locally you will need to install the python libraries defined in the `requirements.txt` file.
 
-<<<<<<< HEAD
-=======
-Then run `python scripts/people.py` to build the list of contributors.
-
->>>>>>> @{-1}
 <!-- markdown-link-check-disable -->
 When these steps are done run `mkdocs serve` to run the server. You can then view the docs at http://localhost:8000/
 <!-- markdown-link-check-enable -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,18 @@
 site_name: Polars User Guide
 site_url: https://pola-rs.github.io/polars-book
 theme:
+  palette:
+  # Palette toggle for light mode
+  - scheme: default
+    toggle:
+      icon: material/brightness-7
+      name: Switch to dark mode
+
+  # Palette toggle for dark mode
+  - scheme: slate
+    toggle:
+      icon: material/brightness-4
+      name: Switch to light mode
   name: material
   custom_dir: overrides
   logo: assets/logo.png
@@ -115,3 +127,4 @@ nav:
       - user-guide/misc/alternatives.md
       - user-guide/misc/reference-guides.md
       - user-guide/misc/contributing.md
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,3 +128,6 @@ nav:
       - user-guide/misc/reference-guides.md
       - user-guide/misc/contributing.md
 
+hooks:
+  - scripts/people.py
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,9 +128,6 @@ nav:
       - user-guide/misc/reference-guides.md
       - user-guide/misc/contributing.md
 
-<<<<<<< HEAD
 hooks:
   - scripts/people.py
 
-=======
->>>>>>> @{-1}

--- a/scripts/people.py
+++ b/scripts/people.py
@@ -5,10 +5,9 @@ g = Github(None)
 
 ICON_TEMPLATE = "[![{login}]({avatar_url}){{.contributor_icon}}]({html_url})"
 
-if __name__ == "__main__":
+def get_people_md():
     repo = g.get_repo("pola-rs/polars")
     contributors = repo.get_contributors()
-
     with open("./docs/people.md", "w") as f:
         for c in itertools.islice(contributors, 50):
             f.write(
@@ -19,3 +18,14 @@ if __name__ == "__main__":
                 )
                 + "\n"
             )
+
+def on_startup(command, dirty):
+    """Mkdocs hook to autogenerate docs/people.md on startup"""
+    try:
+        get_people_md()
+    except Exception as e:
+        msg = f"WARNING:{__file__}: Could not generate docs/people.py. Got error: {str(e)}"
+        print(msg)
+
+if __name__ == "__main__":
+    get_people_md()

--- a/scripts/people.py
+++ b/scripts/people.py
@@ -24,7 +24,7 @@ def on_startup(command, dirty):
     try:
         get_people_md()
     except Exception as e:
-        msg = f"WARNING:{__file__}: Could not generate docs/people.py. Got error: {str(e)}"
+        msg = f"WARNING:{__file__}: Could not generate docs/people.md. Got error: {str(e)}"
         print(msg)
 
 if __name__ == "__main__":

--- a/scripts/people.py
+++ b/scripts/people.py
@@ -5,6 +5,7 @@ g = Github(None)
 
 ICON_TEMPLATE = "[![{login}]({avatar_url}){{.contributor_icon}}]({html_url})"
 
+
 def get_people_md():
     repo = g.get_repo("pola-rs/polars")
     contributors = repo.get_contributors()
@@ -19,6 +20,7 @@ def get_people_md():
                 + "\n"
             )
 
+
 def on_startup(command, dirty):
     """Mkdocs hook to autogenerate docs/people.md on startup"""
     try:
@@ -26,6 +28,7 @@ def on_startup(command, dirty):
     except Exception as e:
         msg = f"WARNING:{__file__}: Could not generate docs/people.md. Got error: {str(e)}"
         print(msg)
+
 
 if __name__ == "__main__":
     get_people_md()


### PR DESCRIPTION
Uses [mkdocs hooks](https://www.mkdocs.org/user-guide/configuration/#hooks) to run the `scripts/people.md` on startup.
Then it's a bit easier for new contributors. 

The time to generate `people.md` is negligible so I don't think it's a problem to always run it, but I get why some people might not agree with having this as a hook.