### PR TITLE
remove mention to sort in Window example

### DIFF
--- a/docs/src/python/user-guide/expressions/window.py
+++ b/docs/src/python/user-guide/expressions/window.py
@@ -69,7 +69,7 @@ pl.sum("foo").over("groups")
 # --8<-- [end:rules]
 
 # --8<-- [start:examples]
-out = df.sort("Type 1").select(
+out = df.select(
     [
         pl.col("Type 1").head(3).implode().over("Type 1").flatten(),
         pl.col("Name")

--- a/docs/user-guide/expressions/window.md
+++ b/docs/user-guide/expressions/window.md
@@ -96,5 +96,3 @@ This still works, but that would give us a column type `List` which might not be
 
 Instead we could `flatten`. This just turns our 2D list into a 1D array and projects that array/column back to our `DataFrame`.
 This is very fast because the reshape is often free, and adding the column back the the original `DataFrame` is also a lot cheaper (since we don't require a join like in a normal window function).
-
-However, for this operation to make sense, it is important that the columns used in `over([..])` are sorted!


### PR DESCRIPTION
Removes the mention of sorting in the Window example.

see discussion here: https://github.com/pola-rs/polars/issues/8958