### PR TITLE
Add rust filter example

### DIFF
--- a/docs/src/rust/getting-started/expressions.rs
+++ b/docs/src/rust/getting-started/expressions.rs
@@ -42,7 +42,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>>{
     // --8<-- [end:exclude]
 
     // --8<-- [start:filter]
-    // TODO
+    let start_date = NaiveDate::from_ymd_opt(2022, 12, 2)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap();
+    let end_date = NaiveDate::from_ymd_opt(2022, 12, 8)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap();
+    let out = df
+        .clone()
+        .lazy()
+        .filter(
+            col("c")
+                .gt_eq(lit(start_date))
+                .and(col("c").lt_eq(lit(end_date))),
+        )
+        .collect()?;
+    println!("{}",out);
     // --8<-- [end:filter]
 
     // --8<-- [start:filter2]


### PR DESCRIPTION
So, I tried to implement one of the `TODO` examples for Rust - the expressions filter example (thought it might be easy).

The related python code:

```python
df.filter(
    pl.col("c").is_between(datetime(2022, 12, 2), datetime(2022, 12, 8)),
)
```

However, I searched the polars rust and couldn't find an `Expr.is_between` method, and all I could figure out for datetime column comparisons was doing `col("c").dt().datetime()`. I also had to use `lit()` because there's no `From<NaiveDateTime>` for `Expr`s. Does this look right? Is there a better way to do this in rust polars? Based on the docs this is supposed to be the "simple" example but it's ... not.