### PR TITLE
Update rust quickstart import on first example

### DIFF
--- a/docs/src/rust/getting-started/series-dataframes.rs
+++ b/docs/src/rust/getting-started/series-dataframes.rs
@@ -1,8 +1,8 @@
 
-use polars::prelude::*;
+use chrono::prelude::*;
 fn main() -> Result<(), Box<dyn std::error::Error>>{
     // --8<-- [start:series]
-    use chrono::prelude::*;
+    use polars::prelude::*;
 
     let s = Series::new("a", [1, 2, 3, 4, 5]);
     println!("{}", s);


### PR DESCRIPTION
Resolves an issue where the import on the QuickStart example reads `use chrono::prelude::*;` rather than `use polars::prelude::*;`

Current version:

<img width="857" alt="image" src="https://github.com/pola-rs/polars-book/assets/1048426/582c6c1d-a20c-4610-9d99-6523b3fa0e4d">



With this change:

<img width="857" alt="image" src="https://github.com/pola-rs/polars-book/assets/1048426/9441390a-5254-4666-ac08-39b0b4e2ac89">
