### PR TITLE
fix: update approx_unique function references

### DIFF
--- a/API_REFERENCE_LINKS.yaml
+++ b/API_REFERENCE_LINKS.yaml
@@ -44,7 +44,7 @@ python:
   suffix: https://pola-rs.github.io/polars/py-polars/html/reference/expressions/api/polars.Expr.suffix.html
   map_alias: https://pola-rs.github.io/polars/py-polars/html/reference/expressions/api/polars.Expr.map_alias.html
   n_unique: https://pola-rs.github.io/polars/py-polars/html/reference/expressions/api/polars.Expr.n_unique.html
-  approx_unique: https://pola-rs.github.io/polars/py-polars/html/reference/expressions/api/polars.approx_unique.html
+  approx_n_unique: https://pola-rs.github.io/polars/py-polars/html/reference/expressions/api/polars.approx_n_unique.html
   when: https://pola-rs.github.io/polars/py-polars/html/reference/expressions/api/polars.when.html
   concat_list: https://pola-rs.github.io/polars/py-polars/html/reference/expressions/api/polars.concat_list.html
   list.eval: https://pola-rs.github.io/polars/py-polars/html/reference/expressions/api/polars.Expr.list.eval.html

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ The `Polars` user guide is intended to live alongside the API documentation. Its
 - [Getting Started](getting-started/intro.md): A 10 minute helicopter view of the library and its primary function.
 - [User Guide](user-guide/index.md): A detailed explanation of how the library is setup and how to use it most effectively. 
 
-If you are looking for details on a specific level / object, it is probably best to go the API documentation: [Python](https://pola-rs.github.io/polars/py-polars/html/reference/index.html) | [NodeJS](https://pola-rs.github.io/polars/polars/index.html) | [Rust](https://pola-rs.github.io/polars/polars/index.html).
+If you are looking for details on a specific level / object, it is probably best to go the API documentation: [Python](https://pola-rs.github.io/polars/py-polars/html/reference/index.html) | [NodeJS](https://pola-rs.github.io/nodejs-polars/index.html) | [Rust](https://docs.rs/polars/latest/polars/).
 
 ## Performance :rocket: :rocket:
 

--- a/docs/src/python/user-guide/expressions/functions.py
+++ b/docs/src/python/user-guide/expressions/functions.py
@@ -43,7 +43,7 @@ print(df_alias)
 # --8<-- [start:countunique]
 df_alias = df.select(
     pl.col("names").n_unique().alias("unique"),
-    pl.approx_unique("names").alias("unique_approx"),
+    pl.approx_n_unique("names").alias("unique_approx"),
 )
 print(df_alias)
 # --8<-- [end:countunique]

--- a/docs/user-guide/expressions/functions.md
+++ b/docs/user-guide/expressions/functions.md
@@ -54,7 +54,7 @@ In case of multiple columns for example when using `all()` or `col(*)` you can a
 There are two ways to count unique values in `Polars`: an exact methodology and an approximation. The approximation uses the [HyperLogLog++](https://en.wikipedia.org/wiki/HyperLogLog) algorithm to approximate the cardinality and is especially useful for very large datasets where an approximation is good enough.
 
 
-{{code_block('user-guide/expressions/functions','countunique',['n_unique','approx_unique'])}}
+{{code_block('user-guide/expressions/functions','countunique',['n_unique','approx_n_unique'])}}
 
 ```python exec="on" result="text" session="user-guide/functions"
 --8<-- "python/user-guide/expressions/functions.py:countunique"

--- a/docs/user-guide/misc/reference-guides.md
+++ b/docs/user-guide/misc/reference-guides.md
@@ -4,4 +4,4 @@ The api documentations with details on function / object signatures can be found
 
 - [NodeJS](https://pola-rs.github.io/nodejs-polars/index.html)
 - [Python](https://pola-rs.github.io/polars/py-polars/html/reference/index.html)
-- [Rust](https://pola-rs.github.io/polars/polars/index.html)
+- [Rust](https://docs.rs/polars/latest/polars/)

--- a/docs/user-guide/sql/select.md
+++ b/docs/user-guide/sql/select.md
@@ -56,7 +56,7 @@ Polars provides a wide range of SQL functions, including:
 - Aggregation functions: `SUM`, `AVG`, `MIN`, `MAX`, `COUNT`, `STDDEV`, `FIRST` etc.
 - Array functions: `EXPLODE`, `UNNEST`,`ARRAY_SUM`,`ARRAY_REVERSE`, etc.
 
-For a full list of supported functions go the [API documentation](https://pola-rs.github.io/polars/src/polars_sql/functions.rs.html). The example below demonstrates how to use a function in a query
+For a full list of supported functions go the [API documentation](https://docs.rs/polars-sql/latest/src/polars_sql/keywords.rs.html). The example below demonstrates how to use a function in a query
 
 {{code_block('user-guide/sql/sql_select','functions',['SQLquery'])}}
 


### PR DESCRIPTION
This PR fixes broken references to the now deprecated function `approx_unique`. References in the Polars user guide are updated to the new function `approx_n_unique`. To see where the code currently breaks check this link: https://pola-rs.github.io/polars-book/user-guide/expressions/functions/#count-unique-values