### PR TITLE
Add documentation for writing polars dataframes to bigquery

### DIFF
--- a/docs/src/python/user-guide/io/bigquery.py
+++ b/docs/src/python/user-guide/io/bigquery.py
@@ -15,4 +15,24 @@ rows = query_job.result()  # Waits for query to finish
 
 df = pl.from_arrow(rows.to_arrow())
 # --8<-- [end:read]
+
+# --8<-- [start:write]
+from google.cloud import bigquery
+
+client = bigquery.Client()
+
+# write dataframe to stream as parquet file; does not hit disk
+with io.BytesIO() as stream:
+    df.write_parquet(stream)
+    stream.seek(0)
+    job = client.load_table_from_file(
+        stream,
+        destination='tablename',
+        project='projectname',
+        job_config=bigquery.LoadJobConfig(
+            source_format=bigquery.SourceFormat.PARQUET,
+        ),
+    )
+job.result()  # Waits for the job to complete
+# --8<-- [end:write]
 """

--- a/docs/src/python/user-guide/io/bigquery.py
+++ b/docs/src/python/user-guide/io/bigquery.py
@@ -21,7 +21,7 @@ from google.cloud import bigquery
 
 client = bigquery.Client()
 
-# write dataframe to stream as parquet file; does not hit disk
+# Write dataframe to stream as parquet file; does not hit disk
 with io.BytesIO() as stream:
     df.write_parquet(stream)
     stream.seek(0)

--- a/docs/user-guide/io/bigquery.md
+++ b/docs/user-guide/io/bigquery.md
@@ -16,4 +16,4 @@ We can load a query into a `DataFrame` like this:
 
 ## Write
 
---8<-- "docs/_build/snippets/under_construction.md"
+{{code_block('user-guide/io/bigquery','write',[])}}


### PR DESCRIPTION
There is currently no documentation for writing polars dataframes to bigquery. This pull request suggests an approach that writes the dataframe as a parquet file to a bytes stream (without saving to disk), and then uses the bigquery API to save the parquet file as a bigquery table.