### PR TITLE
Clarify required imports, fix default formatter for describe

### DIFF
--- a/docs/src/rust/getting-started/series-dataframes.rs
+++ b/docs/src/rust/getting-started/series-dataframes.rs
@@ -1,8 +1,8 @@
 
-use polars::prelude::*;
 fn main() -> Result<(), Box<dyn std::error::Error>>{
     // --8<-- [start:series]
-    use chrono::prelude::*;
+    use polars::prelude::*;
+    use chrono::prelude::*; // This will be needed for the exercise below:
 
     let s = Series::new("a", [1, 2, 3, 4, 5]);
     println!("{}", s);
@@ -50,7 +50,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>>{
     // --8<-- [end:sample]
     
     // --8<-- [start:describe]
-    println!("{}", df.describe(None));
+    println!("{:?}", df.describe(None));
     // --8<-- [end:describe]
     Ok(())
 }

--- a/docs/src/rust/getting-started/series-dataframes.rs
+++ b/docs/src/rust/getting-started/series-dataframes.rs
@@ -1,54 +1,57 @@
-
-fn main() -> Result<(), Box<dyn std::error::Error>>{
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [start:series]
     use polars::prelude::*;
-    use chrono::prelude::*; // This will be needed for the exercise below:
 
     let s = Series::new("a", [1, 2, 3, 4, 5]);
     println!("{}", s);
     // --8<-- [end:series]
-    
+
     // --8<-- [start:minmax]
     let s = Series::new("a", [1, 2, 3, 4, 5]);
     // The use of generics is necessary for the type system
     println!("{}", s.min::<u64>().unwrap());
     println!("{}", s.max::<u64>().unwrap());
     // --8<-- [end:minmax]
-    
+
     // --8<-- [start:string]
     // This operation is not directly available on the Series object yet, only on the DataFrame
     // --8<-- [end:string]
-    
+
     // --8<-- [start:dt]
     // This operation is not directly available on the Series object yet, only on the DataFrame
     // --8<-- [end:dt]
-    
+
     // --8<-- [start:dataframe]
-    let df: DataFrame = df!("integer" => &[1, 2, 3, 4, 5],
-                            "date" => &[
-                                        NaiveDate::from_ymd_opt(2022, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap(),
-                                        NaiveDate::from_ymd_opt(2022, 1, 2).unwrap().and_hms_opt(0, 0, 0).unwrap(),
-                                        NaiveDate::from_ymd_opt(2022, 1, 3).unwrap().and_hms_opt(0, 0, 0).unwrap(),
-                                        NaiveDate::from_ymd_opt(2022, 1, 4).unwrap().and_hms_opt(0, 0, 0).unwrap(),
-                                        NaiveDate::from_ymd_opt(2022, 1, 5).unwrap().and_hms_opt(0, 0, 0).unwrap()
-                            ],
-                            "float" => &[4.0, 5.0, 6.0, 7.0, 8.0]
-                            ).expect("should not fail");
+    use chrono::prelude::*;
+
+    let df: DataFrame = df!(
+        "integer" => &[1, 2, 3, 4, 5],
+        "date" => &[
+            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap(),
+            NaiveDate::from_ymd_opt(2022, 1, 2).unwrap().and_hms_opt(0, 0, 0).unwrap(),
+            NaiveDate::from_ymd_opt(2022, 1, 3).unwrap().and_hms_opt(0, 0, 0).unwrap(),
+            NaiveDate::from_ymd_opt(2022, 1, 4).unwrap().and_hms_opt(0, 0, 0).unwrap(),
+            NaiveDate::from_ymd_opt(2022, 1, 5).unwrap().and_hms_opt(0, 0, 0).unwrap()
+        ],
+        "float" => &[4.0, 5.0, 6.0, 7.0, 8.0],
+    )
+    .unwrap();
+
     println!("{}", df);
     // --8<-- [end:dataframe]
-    
+
     // --8<-- [start:head]
     println!("{}", df.head(Some(3)));
     // --8<-- [end:head]
-    
+
     // --8<-- [start:tail]
     println!("{}", df.tail(Some(3)));
     // --8<-- [end:tail]
-    
+
     // --8<-- [start:sample]
     println!("{}", df.sample_n(2, false, true, None)?);
     // --8<-- [end:sample]
-    
+
     // --8<-- [start:describe]
     println!("{:?}", df.describe(None));
     // --8<-- [end:describe]


### PR DESCRIPTION
I thought it confusing to have only the "import chrono" as the start and thought it was a copy/paste issue, so thought I would clarify the comment and explicitly add the "polars" prelude.

I also noticed that upon enabling the feature "describe" the example didn't work unless I use the `{:?}` pretty-print

```
error[E0277]: `Result<polars::prelude::DataFrame, PolarsError>` doesn't implement `std::fmt::Display`
  --> src/main.rs:53:20
   |
53 |     println!("{}", df.describe(None));
   |                    ^^^^^^^^^^^^^^^^^ `Result<polars::prelude::DataFrame, PolarsError>` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `Result<polars::prelude::DataFrame, PolarsError>`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
```